### PR TITLE
bugfix: for some locales, toLocaleDateString cannot be parsed by Date

### DIFF
--- a/daily_page_template.dev.html
+++ b/daily_page_template.dev.html
@@ -85,7 +85,8 @@
 <script>
     let data = {{DATA|tojson}};
     let today = new Date().toLocaleDateString();
-    let currentTime = new Date(today);
+    let currentTime = new Date();
+    currentTime.setHours(0,0,0,0);
     // console.log(data); // dev purpose only
     $('#today').text(today);
     let yesterday = data[data.length-2];

--- a/daily_page_template.html
+++ b/daily_page_template.html
@@ -85,7 +85,8 @@
 <script>
     let data = {{DATA|tojson}};
     let today = new Date().toLocaleDateString();
-    let currentTime = new Date(today);
+    let currentTime = new Date();
+    currentTime.setHours(0,0,0,0);
     // console.log(data); // dev purpose only
     $('#today').text(today);
     let yesterday = data[data.length-2];

--- a/main_page_template.dev.html
+++ b/main_page_template.dev.html
@@ -264,7 +264,8 @@
 <script>
   //docs @ https://api.highcharts.com/highcharts/
   let data = {{DATA|tojson}};
-  let currentTime = new Date(new Date().toLocaleDateString());
+  let currentTime = new Date();
+  currentTime.setHours(0,0,0,0);
   configFigureMenu();
   setChartGlobalConfig();
   render("3M")

--- a/main_page_template.html
+++ b/main_page_template.html
@@ -264,7 +264,8 @@
 <script>
   //docs @ https://api.highcharts.com/highcharts/
   let data = {{DATA|tojson}};
-  let currentTime = new Date(new Date().toLocaleDateString());
+  let currentTime = new Date();
+  currentTime.setHours(0,0,0,0);
   configFigureMenu();
   setChartGlobalConfig();
   render("3M")


### PR DESCRIPTION
For some locales, this line of code yields an invalid date:
> let currentTime = new Date(new Date().toLocaleDateString());

since `new Date().toLocaleDateString()` is '18-11-2021', which cannot be parsed by Date. Consequently, the dashboard is empty upon opening. This pull request circumvents this problem by using `setHours(0,0,0,0)` to get the current date without a specific time.